### PR TITLE
feat(incidents): Implement dynamic, paginated incident filtering API

### DIFF
--- a/src/main/java/com/telco/incidents/controller/IIncidenciaController.java
+++ b/src/main/java/com/telco/incidents/controller/IIncidenciaController.java
@@ -1,0 +1,25 @@
+package com.telco.incidents.controller;
+
+import com.telco.incidents.dto.IncidenciaResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Incidents Management", description = "API para la gestión y consulta de incidencias")
+public interface IIncidenciaController {
+
+    @Operation(summary = "Buscar y filtrar incidencias",
+            description = "Obtiene una lista paginada de incidencias. Todos los filtros son opcionales. " +
+                    "El acceso está restringido a usuarios con el rol 'ADMIN'.")
+    ResponseEntity<Page<IncidenciaResponseDTO>> searchIncidents(
+            @Parameter(description = "Filtrar por ID de incidencia") @RequestParam(required = false) Long id,
+            @Parameter(description = "Filtrar por ID del técnico asignado") @RequestParam(required = false) Long usuarioId,
+            @Parameter(description = "Filtrar por ID del tipo de incidencia") @RequestParam(required = false) Long tipoId,
+            @Parameter(description = "Filtrar por ID del resultado de la incidencia") @RequestParam(required = false) Long resultadoId,
+            @Parameter(description = "Paginación y ordenamiento (ej. page=0&size=10&sort=fecha,desc)") Pageable pageable
+    );
+}

--- a/src/main/java/com/telco/incidents/controller/impl/IncidenciaControllerImpl.java
+++ b/src/main/java/com/telco/incidents/controller/impl/IncidenciaControllerImpl.java
@@ -1,0 +1,47 @@
+package com.telco.incidents.controller.impl;
+
+import com.telco.incidents.controller.IIncidenciaController;
+import com.telco.incidents.dto.IncidenciaResponseDTO;
+import com.telco.incidents.mapper.IncidenciaMapper;
+import com.telco.incidents.model.Incidencia;
+import com.telco.incidents.service.IIncidenciaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/incidents")
+@RequiredArgsConstructor
+public class IncidenciaControllerImpl implements IIncidenciaController {
+
+    private final IIncidenciaService incidenciaService;
+    private final IncidenciaMapper incidenciaMapper;
+
+    @Override
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')") // Solo los ADMINS pueden acceder.
+    public ResponseEntity<Page<IncidenciaResponseDTO>> searchIncidents(
+            Long id,
+            Long usuarioId,
+            Long tipoId,
+            Long resultadoId,
+            Pageable pageable) {
+
+        // 1. Llamar al servicio para obtener la página de entidades
+        Page<Incidencia> incidenciaPage = incidenciaService.searchIncidents(
+                id, usuarioId, tipoId, resultadoId, pageable
+        );
+
+        // 2. Mapear la página de entidades a una página de DTOs
+        Page<IncidenciaResponseDTO> dtoPage = incidenciaPage.map(incidenciaMapper::toDto);
+
+        // 3. Devolver la página de DTOs en una respuesta 200 OK
+        return ResponseEntity.ok(dtoPage);
+    }
+}

--- a/src/main/java/com/telco/incidents/dto/IncidenciaResponseDTO.java
+++ b/src/main/java/com/telco/incidents/dto/IncidenciaResponseDTO.java
@@ -1,0 +1,17 @@
+package com.telco.incidents.dto;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record IncidenciaResponseDTO(
+        Long id,
+        SimpleClienteDTO cliente,
+        SimpleUserDTO usuarioAsignado,
+        String tipoIncidencia,
+        String resultadoIncidencia,
+        String zona,
+        LocalDateTime fecha,
+        String descripcion,
+        Set<String> etiquetas
+) {
+}

--- a/src/main/java/com/telco/incidents/dto/SimpleClienteDTO.java
+++ b/src/main/java/com/telco/incidents/dto/SimpleClienteDTO.java
@@ -1,0 +1,4 @@
+package com.telco.incidents.dto;
+
+public record SimpleClienteDTO(Long id, String nombre) {
+}

--- a/src/main/java/com/telco/incidents/dto/SimpleUserDTO.java
+++ b/src/main/java/com/telco/incidents/dto/SimpleUserDTO.java
@@ -1,0 +1,4 @@
+package com.telco.incidents.dto;
+
+public record SimpleUserDTO(Long id, String nombre) {
+}

--- a/src/main/java/com/telco/incidents/mapper/IncidenciaMapper.java
+++ b/src/main/java/com/telco/incidents/mapper/IncidenciaMapper.java
@@ -1,0 +1,49 @@
+package com.telco.incidents.mapper;
+
+import com.telco.incidents.dto.IncidenciaResponseDTO;
+import com.telco.incidents.dto.SimpleClienteDTO;
+import com.telco.incidents.dto.SimpleUserDTO;
+import com.telco.incidents.model.Cliente;
+import com.telco.incidents.model.Etiqueta;
+import com.telco.incidents.model.Incidencia;
+import com.telco.users.model.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring")
+public interface IncidenciaMapper {
+
+    // --- Mapeo Principal: de Entidad Incidencia a DTO ---
+
+    @Mapping(source = "usuario", target = "usuarioAsignado")
+    @Mapping(source = "tipoIncidencia.nombre", target = "tipoIncidencia")
+    @Mapping(source = "resultadoIncidencia.descripcion", target = "resultadoIncidencia")
+    @Mapping(source = "zona.nombre", target = "zona")
+    @Mapping(source = "etiquetas", target = "etiquetas", qualifiedByName = "etiquetasToString")
+    IncidenciaResponseDTO toDto(Incidencia incidencia);
+
+
+    // --- Mapeos Auxiliares para objetos anidados ---
+
+    @Mapping(source = "firstName", target = "nombre")
+    SimpleUserDTO userToSimpleUserDto(User user);
+
+    SimpleClienteDTO clienteToSimpleClienteDto(Cliente cliente);
+
+
+    // --- Método Personalizado para convertir Set<Etiqueta> a Set<String> ---
+
+    @Named("etiquetasToString")
+    default Set<String> etiquetasToString(Set<Etiqueta> etiquetas) {
+        if (etiquetas == null) {
+            return null;
+        }
+        return etiquetas.stream()
+                .map(Etiqueta::getNombre)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/telco/incidents/repository/specification/IncidenciaSpecification.java
+++ b/src/main/java/com/telco/incidents/repository/specification/IncidenciaSpecification.java
@@ -1,0 +1,52 @@
+package com.telco.incidents.repository.specification;
+
+import com.telco.incidents.model.*;
+import com.telco.users.model.User;
+import jakarta.persistence.criteria.Join;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IncidenciaSpecification {
+
+    /**
+     * Devuelve una Specification que filtra por el ID de la incidencia.
+     */
+    public static Specification<Incidencia> hasId(Long id) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("id"), id);
+    }
+
+    /**
+     * Devuelve una Specification que filtra por el ID del técnico (Usuario) asignado.
+     * Realiza un JOIN con la tabla de Usuario.
+     */
+    public static Specification<Incidencia> hasUsuarioId(Long usuarioId) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Incidencia, User> usuarioJoin = root.join("usuario");
+            return criteriaBuilder.equal(usuarioJoin.get("id"), usuarioId);
+        };
+    }
+
+    /**
+     * Devuelve una Specification que filtra por el ID del tipo de incidencia.
+     * Realiza un JOIN con la tabla de TipoIncidencia.
+     */
+    public static Specification<Incidencia> hasTipoId(Long tipoId) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Incidencia, TipoIncidencia> tipoJoin = root.join("tipoIncidencia");
+            return criteriaBuilder.equal(tipoJoin.get("id"), tipoId);
+        };
+    }
+
+    /**
+     * Devuelve una Specification que filtra por el ID del resultado de la incidencia.
+     * Realiza un JOIN con la tabla de ResultadoIncidencia.
+     */
+    public static Specification<Incidencia> hasResultadoId(Long resultadoId) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Incidencia, ResultadoIncidencia> resultadoJoin = root.join("resultadoIncidencia");
+            return criteriaBuilder.equal(resultadoJoin.get("id"), resultadoId);
+        };
+    }
+}

--- a/src/main/java/com/telco/incidents/service/IIncidenciaService.java
+++ b/src/main/java/com/telco/incidents/service/IIncidenciaService.java
@@ -1,0 +1,27 @@
+package com.telco.incidents.service;
+
+import com.telco.incidents.model.Incidencia;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface IIncidenciaService {
+
+    /**
+     * Busca y filtra incidencias de forma paginada.
+     * Los filtros son opcionales. Si un filtro es nulo, no se aplicará.
+     *
+     * @param id          ID de la incidencia para búsqueda directa (opcional).
+     * @param usuarioId   ID del técnico asignado para filtrar (opcional).
+     * @param tipoId      ID del tipo de incidencia para filtrar (opcional).
+     * @param resultadoId ID del resultado de la incidencia para filtrar (opcional).
+     * @param pageable    Objeto que contiene la información de paginación y ordenamiento.
+     * @return una página (Page) de objetos Incidencia que coinciden con los criterios.
+     */
+    Page<Incidencia> searchIncidents(
+            Long id,
+            Long usuarioId,
+            Long tipoId,
+            Long resultadoId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/telco/incidents/service/impl/IncidenciaServiceImpl.java
+++ b/src/main/java/com/telco/incidents/service/impl/IncidenciaServiceImpl.java
@@ -1,0 +1,49 @@
+package com.telco.incidents.service.impl;
+
+import com.telco.incidents.model.Incidencia;
+import com.telco.incidents.repository.IIncidenciaRepository;
+import com.telco.incidents.repository.specification.IncidenciaSpecification;
+import com.telco.incidents.service.IIncidenciaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // Todas las búsquedas son de solo lectura por defecto
+public class IncidenciaServiceImpl implements IIncidenciaService {
+
+    private final IIncidenciaRepository incidenciaRepository;
+
+    @Override
+    public Page<Incidencia> searchIncidents(
+            Long id,
+            Long usuarioId,
+            Long tipoId,
+            Long resultadoId,
+            Pageable pageable) {
+
+        // 1. Empezamos con una especificación que no hace nada (devuelve todo).
+        Specification<Incidencia> spec = Specification.where(null);
+
+        // 2. Añadimos condiciones dinámicamente solo si el filtro no es nulo.
+        if (id != null) {
+            spec = spec.and(IncidenciaSpecification.hasId(id));
+        }
+        if (usuarioId != null) {
+            spec = spec.and(IncidenciaSpecification.hasUsuarioId(usuarioId));
+        }
+        if (tipoId != null) {
+            spec = spec.and(IncidenciaSpecification.hasTipoId(tipoId));
+        }
+        if (resultadoId != null) {
+            spec = spec.and(IncidenciaSpecification.hasResultadoId(resultadoId));
+        }
+
+        // 3. Ejecutamos la consulta final con todos los filtros combinados y la paginación.
+        return incidenciaRepository.findAll(spec, pageable);
+    }
+}


### PR DESCRIPTION
This commit introduces a complete, secure, and robust backend feature for searching and filtering support incidents.

Key implementations include:
- A full data model with JPA entities for Incidencia, Cliente, Nota, and related catalogs.
- A dynamic search service leveraging JPA Specifications to allow filtering by ID, technician, incident type, and result.
- A REST endpoint GET /api/incidents protected with role-based authorization, accessible only to ADMIN users.
- DTOs and MapStruct mappers to provide clean and secure data contracts for the API.
- An enhanced DataLoader to populate the database with diverse test data, ensuring a ready-to-use development environment.
- This feature provides the core functionality for the incident history and search module.