### PR TITLE
feat(incidents): Implement incident creation endpoint

### DIFF
--- a/src/main/java/com/telco/incidents/controller/IIncidenciaController.java
+++ b/src/main/java/com/telco/incidents/controller/IIncidenciaController.java
@@ -1,12 +1,17 @@
 package com.telco.incidents.controller;
 
+import com.telco.incidents.dto.IncidenciaRequestDTO;
+import com.telco.incidents.dto.IncidenciaResponseDTO;
 import com.telco.incidents.dto.IncidenciaResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Incidents Management", description = "API para la gestión y consulta de incidencias")
@@ -22,4 +27,22 @@ public interface IIncidenciaController {
             @Parameter(description = "Filtrar por ID del resultado de la incidencia") @RequestParam(required = false) Long resultadoId,
             @Parameter(description = "Paginación y ordenamiento (ej. page=0&size=10&sort=fecha,desc)") Pageable pageable
     );
+
+    /**
+     * Crea una nueva incidencia en el sistema.
+     * Requiere rol de OPERATOR o ADMIN.
+     *
+     * @param requestDTO El cuerpo de la solicitud con los datos de la incidencia.
+     * @return Una respuesta con la incidencia recién creada y un estado 201 (Created).
+     */
+    @Operation(
+            summary = "Crear una nueva incidencia",
+            description = "Registra una nueva incidencia en el sistema. El acceso está restringido.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Incidencia creada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos de entrada inválidos"),
+                    @ApiResponse(responseCode = "403", description = "Acceso denegado")
+            }
+    )
+    ResponseEntity<IncidenciaResponseDTO> crearIncidencia(@Valid @RequestBody IncidenciaRequestDTO requestDTO);
 }

--- a/src/main/java/com/telco/incidents/controller/impl/IncidenciaControllerImpl.java
+++ b/src/main/java/com/telco/incidents/controller/impl/IncidenciaControllerImpl.java
@@ -14,6 +14,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.telco.incidents.dto.IncidenciaRequestDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.telco.incidents.controller.IIncidenciaController;
 
 @RestController
 @RequestMapping("/api/incidents")
@@ -43,5 +50,20 @@ public class IncidenciaControllerImpl implements IIncidenciaController {
 
         // 3. Devolver la página de DTOs en una respuesta 200 OK
         return ResponseEntity.ok(dtoPage);
+    }
+
+    @Override
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
+    public ResponseEntity<IncidenciaResponseDTO> crearIncidencia(@Valid @RequestBody IncidenciaRequestDTO requestDTO) {
+
+        // 1. Llamar al servicio para crear la entidad
+        Incidencia nuevaIncidencia = incidenciaService.crearIncidencia(requestDTO);
+
+        // 2. Mapear la entidad guardada a un DTO de respuesta
+        IncidenciaResponseDTO responseDTO = incidenciaMapper.toDto(nuevaIncidencia);
+
+        // 3. Devolver una respuesta 201 Created
+        return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/telco/incidents/dto/IncidenciaRequestDTO.java
+++ b/src/main/java/com/telco/incidents/dto/IncidenciaRequestDTO.java
@@ -1,0 +1,32 @@
+package com.telco.incidents.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Set;
+
+public record IncidenciaRequestDTO(
+        @NotNull(message = "El ID del cliente no puede ser nulo.")
+        Long clienteId,
+
+        @NotNull(message = "El ID del usuario (técnico) no puede ser nulo.")
+        Long usuarioId,
+
+        @NotNull(message = "El ID del tipo de incidencia no puede ser nulo.")
+        Long tipoId,
+
+        @NotNull(message = "El ID de la zona no puede ser nulo.")
+        Long zonaId,
+
+        // El resultado es opcional al crear, se asignará después.
+        Long resultadoId,
+
+        @NotBlank(message = "La descripción no puede estar vacía.")
+        @Size(max = 1000, message = "La descripción no puede exceder los 1000 caracteres.")
+        String descripcion,
+
+        // Las etiquetas son opcionales. Se envían los IDs de las etiquetas existentes.
+        Set<Long> etiquetaIds
+) {
+}

--- a/src/main/java/com/telco/incidents/service/IIncidenciaService.java
+++ b/src/main/java/com/telco/incidents/service/IIncidenciaService.java
@@ -1,6 +1,7 @@
 package com.telco.incidents.service;
 
 import com.telco.incidents.model.Incidencia;
+import com.telco.incidents.dto.IncidenciaRequestDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -24,4 +25,11 @@ public interface IIncidenciaService {
             Long resultadoId,
             Pageable pageable
     );
+
+    /**
+     * Crea una nueva incidencia a partir de los datos de la solicitud.
+     * @param requestDTO DTO con los datos para la nueva incidencia.
+     * @return La entidad Incidencia recién creada y guardada.
+     */
+    Incidencia crearIncidencia(IncidenciaRequestDTO requestDTO);
 }

--- a/src/main/java/com/telco/incidents/service/impl/IncidenciaServiceImpl.java
+++ b/src/main/java/com/telco/incidents/service/impl/IncidenciaServiceImpl.java
@@ -1,9 +1,13 @@
 package com.telco.incidents.service.impl;
 
-import com.telco.incidents.model.Incidencia;
-import com.telco.incidents.repository.IIncidenciaRepository;
+import com.telco.incidents.dto.IncidenciaRequestDTO;
+import com.telco.incidents.model.*;
+import com.telco.incidents.repository.*;
 import com.telco.incidents.repository.specification.IncidenciaSpecification;
 import com.telco.incidents.service.IIncidenciaService;
+import com.telco.users.model.User;
+import com.telco.users.repository.IUserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,14 +15,24 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true) // Todas las búsquedas son de solo lectura por defecto
 public class IncidenciaServiceImpl implements IIncidenciaService {
 
     private final IIncidenciaRepository incidenciaRepository;
+    private final IClienteRepository clienteRepository;
+    private final IUserRepository userRepository;
+    private final ITipoIncidenciaRepository tipoIncidenciaRepository;
+    private final IZonaRepository zonaRepository;
+    private final IResultadoIncidenciaRepository resultadoIncidenciaRepository;
+    private final IEtiquetaRepository etiquetaRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Page<Incidencia> searchIncidents(
             Long id,
             Long usuarioId,
@@ -45,5 +59,50 @@ public class IncidenciaServiceImpl implements IIncidenciaService {
 
         // 3. Ejecutamos la consulta final con todos los filtros combinados y la paginación.
         return incidenciaRepository.findAll(spec, pageable);
+    }
+
+    @Override
+    @Transactional
+    public Incidencia crearIncidencia(IncidenciaRequestDTO dto) {
+        // 1. "Hidratar" las entidades a partir de los IDs
+        Cliente cliente = clienteRepository.findById(dto.clienteId())
+                .orElseThrow(() -> new EntityNotFoundException("Cliente no encontrado con ID: " + dto.clienteId()));
+
+        User usuario = userRepository.findById(dto.usuarioId())
+                .orElseThrow(() -> new EntityNotFoundException("Usuario no encontrado con ID: " + dto.usuarioId()));
+
+        TipoIncidencia tipo = tipoIncidenciaRepository.findById(dto.tipoId())
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de Incidencia no encontrado con ID: " + dto.tipoId()));
+
+        Zona zona = zonaRepository.findById(dto.zonaId())
+                .orElseThrow(() -> new EntityNotFoundException("Zona no encontrada con ID: " + dto.zonaId()));
+
+        // El resultado es opcional, lo buscamos solo si se proporciona un ID
+        ResultadoIncidencia resultado = null;
+        if (dto.resultadoId() != null) {
+            resultado = resultadoIncidenciaRepository.findById(dto.resultadoId())
+                    .orElseThrow(() -> new EntityNotFoundException("Resultado no encontrado con ID: " + dto.resultadoId()));
+        }
+
+        // Las etiquetas son opcionales
+        Set<Etiqueta> etiquetas = new HashSet<>();
+        if (dto.etiquetaIds() != null && !dto.etiquetaIds().isEmpty()) {
+            etiquetas = new HashSet<>(etiquetaRepository.findAllById(dto.etiquetaIds()));
+        }
+
+        // 2. Construir la nueva entidad Incidencia
+        Incidencia nuevaIncidencia = new Incidencia();
+        nuevaIncidencia.setCliente(cliente);
+        nuevaIncidencia.setUsuario(usuario);
+        nuevaIncidencia.setTipoIncidencia(tipo);
+        nuevaIncidencia.setZona(zona);
+        nuevaIncidencia.setResultadoIncidencia(resultado); // Será null si no se proporcionó
+        nuevaIncidencia.setDescripcion(dto.descripcion());
+        nuevaIncidencia.setEtiquetas(etiquetas);
+
+        // La fecha se asigna automáticamente con @CreationTimestamp
+
+        // 3. Guardar y devolver la nueva entidad
+        return incidenciaRepository.save(nuevaIncidencia);
     }
 }


### PR DESCRIPTION
This commit introduces the functionality to create new support incidents via a secure REST API endpoint.

Key implementations include:
- A new endpoint POST /api/incidents to handle the creation logic.
- An IncidenciaRequestDTO with robust validation (@NotNull, @Size) to ensure data integrity from the client.
- The service layer now handles the "hydration" of entities from incoming IDs, with error handling for non-existent entities (e.g., invalid clienteId).
- Role-based authorization has been applied using @PreAuthorize, restricting access to users with 'ADMIN' or 'OPERATOR' roles.
- The API returns a 201 Created status with the full DTO of the newly created incident upon success, following REST best practices.