### PR TITLE
feat(users): Implement user role management and deletion

### DIFF
--- a/src/main/java/com/telco/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/telco/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.telco.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Maneja las excepciones de tipo EntityNotFoundException.
+     * Se activa cuando un servicio lanza esta excepción (ej. al no encontrar un usuario o rol).
+     * Devuelve una respuesta HTTP 404 Not Found.
+     *
+     * @param ex La excepción capturada.
+     * @param request La solicitud web actual.
+     * @return Una ResponseEntity con el código 404 y un cuerpo de error claro.
+     */
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Object> handleEntityNotFoundException(EntityNotFoundException ex, WebRequest request) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.NOT_FOUND.value());
+        body.put("error", "Not Found");
+        body.put("message", ex.getMessage());
+        body.put("path", request.getDescription(false).replace("uri=", ""));
+
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+    
+}

--- a/src/main/java/com/telco/users/controller/IUserController.java
+++ b/src/main/java/com/telco/users/controller/IUserController.java
@@ -1,0 +1,35 @@
+package com.telco.users.controller;
+
+import com.telco.users.dto.UpdateUserRoleRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User Management", description = "API para la gestión de usuarios (roles, eliminación, etc.)")
+@SecurityRequirement(name = "bearerAuth")
+public interface IUserController {
+
+    @Operation(summary = "Actualizar el rol de un usuario", description = "Permite a un administrador cambiar el rol de un usuario existente.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Rol actualizado exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Usuario o Rol no encontrado"),
+                    @ApiResponse(responseCode = "403", description = "Acceso denegado")
+            })
+    ResponseEntity<Void> updateUserRole(
+            @Parameter(description = "ID del usuario a modificar") @PathVariable Long id,
+            @Valid @RequestBody UpdateUserRoleRequestDTO requestDTO);
+
+    @Operation(summary = "Eliminar un usuario", description = "Permite a un administrador eliminar un usuario del sistema.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Usuario eliminado exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Usuario no encontrado"),
+                    @ApiResponse(responseCode = "403", description = "Acceso denegado")
+            })
+    ResponseEntity<Void> deleteUser(@Parameter(description = "ID del usuario a eliminar") @PathVariable Long id);
+}

--- a/src/main/java/com/telco/users/controller/impl/UserControllerImpl.java
+++ b/src/main/java/com/telco/users/controller/impl/UserControllerImpl.java
@@ -1,0 +1,34 @@
+package com.telco.users.controller.impl;
+
+import com.telco.users.controller.IUserController;
+import com.telco.users.dto.UpdateUserRoleRequestDTO;
+import com.telco.users.service.IUserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserControllerImpl implements IUserController {
+
+    private final IUserService userService;
+
+    @Override
+    @PatchMapping("/{id}/role")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> updateUserRole(@PathVariable Long id, @Valid @RequestBody UpdateUserRoleRequestDTO requestDTO) {
+        userService.updateUserRole(id, requestDTO.newRoleId());
+        return ResponseEntity.noContent().build(); // Devuelve 204 No Content
+    }
+
+    @Override
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build(); // Devuelve 204 No Content
+    }
+}

--- a/src/main/java/com/telco/users/dto/UpdateUserRoleRequestDTO.java
+++ b/src/main/java/com/telco/users/dto/UpdateUserRoleRequestDTO.java
@@ -1,0 +1,9 @@
+package com.telco.users.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUserRoleRequestDTO(
+        @NotNull(message = "El ID del nuevo rol no puede ser nulo.")
+        Long newRoleId
+) {
+}

--- a/src/main/java/com/telco/users/service/IUserService.java
+++ b/src/main/java/com/telco/users/service/IUserService.java
@@ -1,8 +1,6 @@
 package com.telco.users.service;
 
-// En el futuro, podríamos añadir aquí otros métodos de negocio, como:
-// import com.telco.users.dto.UserResponseDto;
-// import java.util.List;
+import com.telco.users.model.User;
 
 /**
  * Interfaz que define el contrato para los servicios de negocio relacionados con los usuarios.
@@ -11,6 +9,17 @@ package com.telco.users.service;
  */
 public interface IUserService {
 
-    // Por ahora, esta interfaz puede permanecer vacía. Su propósito principal es
-    // establecer un buen patrón de diseño.
+    /**
+     * Actualiza el rol de un usuario existente.
+     * @param userId El ID del usuario a modificar.
+     * @param newRoleId El ID del nuevo rol a asignar.
+     * @return El usuario actualizado.
+     */
+    User updateUserRole(Long userId, Long newRoleId);
+
+    /**
+     * Elimina un usuario del sistema.
+     * @param userId El ID del usuario a eliminar.
+     */
+    void deleteUser(Long userId);
 }

--- a/src/main/java/com/telco/users/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/telco/users/service/impl/UserServiceImpl.java
@@ -8,6 +8,13 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.telco.users.model.Rol;
+import com.telco.users.repository.RolRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.telco.users.model.User;
+
 /**
  * Implementación del servicio de usuarios.
  */
@@ -16,6 +23,7 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements IUserService, UserDetailsService {
 
     private final IUserRepository userRepository;
+    private final RolRepository rolRepository;
 
     /**
      * Implementación del método de la interfaz UserDetailsService.
@@ -32,5 +40,30 @@ public class UserServiceImpl implements IUserService, UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException("User with username '" + username + "' not found."));
     }
 
-    // Aquí irían las implementaciones de los métodos definidos en IUserService.
+    @Override
+    @Transactional
+    public User updateUserRole(Long userId, Long newRoleId) {
+        // 1. Buscar el usuario
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Usuario no encontrado con ID: " + userId));
+
+        // 2. Buscar el nuevo rol
+        Rol newRol = rolRepository.findById(newRoleId)
+                .orElseThrow(() -> new EntityNotFoundException("Rol no encontrado con ID: " + newRoleId));
+
+        // 3. Actualizar el rol y guardar
+        user.setRol(newRol);
+        return userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void deleteUser(Long userId) {
+        // 1. Verificar si el usuario existe antes de intentar borrarlo
+        if (!userRepository.existsById(userId)) {
+            throw new EntityNotFoundException("Usuario no encontrado con ID: " + userId);
+        }
+        // 2. Eliminar el usuario
+        userRepository.deleteById(userId);
+    }
 }


### PR DESCRIPTION
This commit introduces critical administrative capabilities for user management, allowing administrators to maintain a clean and secure user base.

Key Features Implemented:
- **Update User Role:** A new endpoint `PATCH /api/users/{id}/role` allows users with the 'ADMIN' role to change the role of any existing user. The service layer validates the existence of both the user and the new role before applying the change.
- **Delete User:** A new endpoint `DELETE /api/users/{id}` enables administrators to permanently remove users from the system.
- **Security:** Both endpoints are secured using @PreAuthorize, ensuring that only authorized administrators can perform these sensitive operations.
- **Error Handling:** Implemented a GlobalExceptionHandler to gracefully handle `EntityNotFoundException`, returning a proper 404 Not Found status code instead of a generic server error. This improves API clarity and client-side error management.