### PR TITLE
feat(incidents): Implement endpoint to get incident by ID

### DIFF
--- a/src/main/java/com/telco/incidents/controller/IIncidenciaController.java
+++ b/src/main/java/com/telco/incidents/controller/IIncidenciaController.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import org.springframework.web.bind.annotation.PathVariable;
+
 @Tag(name = "Incidents Management", description = "API para la gestión y consulta de incidencias")
 public interface IIncidenciaController {
 
@@ -45,4 +47,19 @@ public interface IIncidenciaController {
             }
     )
     ResponseEntity<IncidenciaResponseDTO> crearIncidencia(@Valid @RequestBody IncidenciaRequestDTO requestDTO);
+
+    /**
+     * Obtiene los detalles de una incidencia específica por su ID.
+     * @param id El ID de la incidencia a recuperar.
+     * @return Una respuesta con el DTO de la incidencia y un estado 200 OK.
+     */
+    @Operation(summary = "Obtener detalle de una incidencia por ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Incidencia encontrada"),
+                    @ApiResponse(responseCode = "404", description = "Incidencia no encontrada"),
+                    @ApiResponse(responseCode = "403", description = "Acceso denegado")
+            })
+    ResponseEntity<IncidenciaResponseDTO> getIncidenciaById(
+            @Parameter(description = "ID de la incidencia") @PathVariable Long id
+    );
 }

--- a/src/main/java/com/telco/incidents/controller/impl/IncidenciaControllerImpl.java
+++ b/src/main/java/com/telco/incidents/controller/impl/IncidenciaControllerImpl.java
@@ -20,6 +20,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
 import com.telco.incidents.controller.IIncidenciaController;
 
 @RestController
@@ -65,5 +68,20 @@ public class IncidenciaControllerImpl implements IIncidenciaController {
 
         // 3. Devolver una respuesta 201 Created
         return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
+    }
+
+    @Override
+    @GetMapping("/{id}") // Mapea a peticiones GET a /api/incidents/{un_numero}
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPERVISOR', 'TECHNICIAN')") // Permitimos que todos los usuarios logueados vean los detalles
+    public ResponseEntity<IncidenciaResponseDTO> getIncidenciaById(@PathVariable Long id) {
+
+        // 1. Llamar al servicio para buscar la entidad
+        Incidencia incidencia = incidenciaService.findById(id);
+
+        // 2. Mapear la entidad a un DTO de respuesta
+        IncidenciaResponseDTO responseDTO = incidenciaMapper.toDto(incidencia);
+
+        // 3. Devolver el DTO en una respuesta 200 OK
+        return ResponseEntity.ok(responseDTO);
     }
 }

--- a/src/main/java/com/telco/incidents/service/IIncidenciaService.java
+++ b/src/main/java/com/telco/incidents/service/IIncidenciaService.java
@@ -32,4 +32,12 @@ public interface IIncidenciaService {
      * @return La entidad Incidencia recién creada y guardada.
      */
     Incidencia crearIncidencia(IncidenciaRequestDTO requestDTO);
+
+    /**
+     * Busca una única incidencia por su ID.
+     * @param id El ID de la incidencia a buscar.
+     * @return La entidad Incidencia si se encuentra.
+     * @throws jakarta.persistence.EntityNotFoundException si no se encuentra la incidencia.
+     */
+    Incidencia findById(Long id);
 }

--- a/src/main/java/com/telco/incidents/service/impl/IncidenciaServiceImpl.java
+++ b/src/main/java/com/telco/incidents/service/impl/IncidenciaServiceImpl.java
@@ -15,6 +15,8 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityNotFoundException;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -104,5 +106,12 @@ public class IncidenciaServiceImpl implements IIncidenciaService {
 
         // 3. Guardar y devolver la nueva entidad
         return incidenciaRepository.save(nuevaIncidencia);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Incidencia findById(Long id) {
+        return incidenciaRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Incidencia no encontrada con ID: " + id));
     }
 }


### PR DESCRIPTION
This commit introduces the functionality to retrieve a single support incident by its unique identifier, a core requirement for viewing incident details.

Key implementations include:
- A new REST endpoint GET /api/incidents/{id} to fetch a specific incident.
- The service layer now includes a findById method that retrieves the entity from the database or throws a clear EntityNotFoundException.
- The endpoint is secured with @PreAuthorize, allowing access to all authenticated user roles (ADMIN, SUPERVISOR, TECHNICIAN).
- This new endpoint is fundamental for client applications to display detailed ticket information and will serve as a target for future HATEOAS links.